### PR TITLE
Updated UI design for social profiles pages

### DIFF
--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithCard.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithCard.xaml
@@ -44,6 +44,12 @@
                         Stroke="Transparent"
                         Grid.Row="0"
                         Margin="16,0,16,32">
+                    <Border.Shadow>
+                        <Shadow Brush="Black"
+                                    Opacity="0.16"
+                                    Radius="3"
+                                    Offset="0,1"/>
+                    </Border.Shadow>
 
                     <Border
                         Stroke="Transparent"
@@ -58,7 +64,7 @@
                             <Image
                                 Aspect="Fill"
                                 BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                                HeightRequest="120"
+                                HeightRequest="190"
                                 HorizontalOptions="Fill">
                                 <Image.Source>
                                     <UriImageSource
@@ -69,7 +75,7 @@
                             </Image>
 
                             <Border
-                                Margin="0,-60,0,16"
+                                Margin="0,-45,0,16"
                                 BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
                                 Stroke="{DynamicResource Gray-White}"
                                 StrokeThickness="2"
@@ -130,19 +136,6 @@
 
                             </StackLayout>
 
-                            <!--  Follow button  -->
-                            <buttons:SfButton
-                                Margin="0,0,0,16"
-                                CornerRadius="24"
-                                FontSize="14"
-                                Stroke="{AppThemeBinding Light={DynamicResource PrimaryColorLight}, Dark={DynamicResource PrimaryColorDark}}"
-                                FontFamily="Roboto-Medium"
-                                Background="Transparent"
-                                Text="Follow"
-                                TextColor="{AppThemeBinding Light={DynamicResource PrimaryColorLight}, Dark={DynamicResource PrimaryColorDark}}"
-                                WidthRequest="120">
-                            </buttons:SfButton>
-
                             <!--  About title label  -->
                             <Label
                                 Margin="16,0,0,4"
@@ -160,6 +153,20 @@
                                 HorizontalTextAlignment="Start"
                                 Style="{DynamicResource DescriptionLabelStyle}"
                                 Text="{Binding Profile.About}"/>
+
+                            <!--  Follow button  -->
+                            <buttons:SfButton
+                                Margin="0,0,0,16"
+                                CornerRadius="24"
+                                FontSize="14"
+                                Stroke="{AppThemeBinding Light={DynamicResource PrimaryColorLight}, Dark={DynamicResource PrimaryColorDark}}"
+                                StrokeThickness="2"
+                                FontFamily="Roboto-Medium"
+                                Background="Transparent"
+                                Text="Follow"
+                                TextColor="{AppThemeBinding Light={DynamicResource PrimaryColorLight}, Dark={DynamicResource PrimaryColorDark}}"
+                                WidthRequest="180">
+                            </buttons:SfButton>
 
                         </StackLayout>
                     </Border>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithConnectionsPage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithConnectionsPage.xaml
@@ -206,7 +206,7 @@
                                       Background="Transparent"
                                       FontFamily="Roboto-Medium"
                                       TextColor="{AppThemeBinding Light={DynamicResource PrimaryTextColorLight}, Dark={DynamicResource PrimaryTextColorDark}}"
-                                      WidthRequest="{OnPlatform MacCatalyst=300, WinUI=300}"/>
+                                      WidthRequest="{OnPlatform Android=170, MacCatalyst=300, WinUI=300}"/>
                     <buttons:SfButton Margin="10"
                                       Text="Share Profile"
                                       Stroke="#E5E1E3"
@@ -214,7 +214,7 @@
                                       Background="Transparent"
                                       FontFamily="Roboto-Medium"
                                       TextColor="{AppThemeBinding Light={DynamicResource PrimaryTextColorLight}, Dark={DynamicResource PrimaryTextColorDark}}"
-                                      WidthRequest="{OnPlatform MacCatalyst=300, WinUI=300}"/>
+                                      WidthRequest="{OnPlatform Android=170, MacCatalyst=300, WinUI=300}"/>
                 </StackLayout>
 
                 <!--  Connection title label  -->

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithConnectionsPage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithConnectionsPage.xaml
@@ -206,7 +206,7 @@
                                       Background="Transparent"
                                       FontFamily="Roboto-Medium"
                                       TextColor="{AppThemeBinding Light={DynamicResource PrimaryTextColorLight}, Dark={DynamicResource PrimaryTextColorDark}}"
-                                      WidthRequest="{OnPlatform Android=170, MacCatalyst=300, WinUI=300}"/>
+                                      WidthRequest="{OnIdiom Phone=170, Tablet=380, Desktop=300}"/>
                     <buttons:SfButton Margin="10"
                                       Text="Share Profile"
                                       Stroke="#E5E1E3"
@@ -214,7 +214,7 @@
                                       Background="Transparent"
                                       FontFamily="Roboto-Medium"
                                       TextColor="{AppThemeBinding Light={DynamicResource PrimaryTextColorLight}, Dark={DynamicResource PrimaryTextColorDark}}"
-                                      WidthRequest="{OnPlatform Android=170, MacCatalyst=300, WinUI=300}"/>
+                                      WidthRequest="{OnIdiom Phone=170, Tablet=380, Desktop=300}"/>
                 </StackLayout>
 
                 <!--  Connection title label  -->

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithConnectionsPage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithConnectionsPage.xaml
@@ -201,27 +201,27 @@
                              Orientation="Horizontal">
                     <buttons:SfButton Margin="10"
                                       Text="Edit Profile"
-                                      Stroke="Gray"
-                                      StrokeThickness="1"
+                                      Stroke="#E5E1E3"
+                                      StrokeThickness="2"
                                       Background="Transparent"
                                       FontFamily="Roboto-Medium"
                                       TextColor="{AppThemeBinding Light={DynamicResource PrimaryTextColorLight}, Dark={DynamicResource PrimaryTextColorDark}}"
-                                      WidthRequest="{OnPlatform MacCatalyst=280, WinUI=280}"/>
+                                      WidthRequest="{OnPlatform MacCatalyst=300, WinUI=300}"/>
                     <buttons:SfButton Margin="10"
                                       Text="Share Profile"
-                                      Stroke="Gray"
-                                      StrokeThickness="1"
+                                      Stroke="#E5E1E3"
+                                      StrokeThickness="2"
                                       Background="Transparent"
                                       FontFamily="Roboto-Medium"
                                       TextColor="{AppThemeBinding Light={DynamicResource PrimaryTextColorLight}, Dark={DynamicResource PrimaryTextColorDark}}"
-                                      WidthRequest="{OnPlatform MacCatalyst=280, WinUI=280}"/>
+                                      WidthRequest="{OnPlatform MacCatalyst=300, WinUI=300}"/>
                 </StackLayout>
 
                 <!--  Connection title label  -->
                 <Label
                     Grid.Row="4"
                     Grid.ColumnSpan="2"
-                    Margin="16,0,0,0"
+                    Margin="16,25,0,0"
                     FontSize="16"
                     HorizontalOptions="Start"
                     Style="{DynamicResource TitleLabelStyle}"

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithInterest.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithInterest.xaml
@@ -101,14 +101,14 @@
                            x:Name="picture"
                            Aspect="AspectFill"
                            BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                           HeightRequest="80"
+                           HeightRequest="90"
                            Source="{Binding Profile.ProfileImage}"
-                           WidthRequest="80"/>
+                           WidthRequest="90"/>
                 </Border>
 
                 <Grid Grid.Row="3"
                       Margin="16,0,0,24"
-                      ColumnDefinitions="Auto, Auto"
+                      ColumnDefinitions="*, Auto"
                       ColumnSpacing="0"
                       RowDefinitions="Auto, Auto"
                       RowSpacing="0">
@@ -117,7 +117,7 @@
                     <Label
                         Grid.Row="0"
                         Grid.Column="0"
-                        Margin="0,0,0,2"
+                        Margin="0,20,0,2"
                         FontSize="20"
                         HorizontalOptions="Start"
                         HorizontalTextAlignment="Start"
@@ -170,16 +170,16 @@
                         Text="Follow"
                         VerticalOptions="End"
                         HorizontalOptions="End"
-                        WidthRequest="120">
+                        WidthRequest="100">
                     </buttons:SfButton>
 
                 </Grid>
 
-                <Grid Grid.Row="4"
-                      Margin="16,0,16,32"
-                      ColumnDefinitions="Auto, *, Auto, *, Auto"
-                      ColumnSpacing="0"
-                      HorizontalOptions="Fill"
+                <Grid Grid.Row="2"
+                      Margin="-240,0,0,0"
+                      ColumnDefinitions="Auto,Auto,Auto,Auto,Auto"
+                      ColumnSpacing="12"
+                      HorizontalOptions="Center"
                       RowDefinitions="Auto, Auto"
                       RowSpacing="0">
 

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithInterest.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithInterest.xaml
@@ -176,7 +176,7 @@
                 </Grid>
 
                 <Grid Grid.Row="2"
-                      Margin="{OnPlatform Default='-240,0,0,0', Android='0,0,-100,0'}"
+                      Margin="{OnIdiom Phone='0,0,-100,0',  Tablet='-360,0,0,0', Desktop='-240,0,0,0'}"
                       ColumnDefinitions="Auto,Auto,Auto,Auto,Auto"
                       ColumnSpacing="12"
                       HorizontalOptions="Center"

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithInterest.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Social/SocialProfileWithInterest.xaml
@@ -176,7 +176,7 @@
                 </Grid>
 
                 <Grid Grid.Row="2"
-                      Margin="-240,0,0,0"
+                      Margin="{OnPlatform Default='-240,0,0,0', Android='0,0,-100,0'}"
                       ColumnDefinitions="Auto,Auto,Auto,Auto,Auto"
                       ColumnSpacing="12"
                       HorizontalOptions="Center"


### PR DESCRIPTION
## Description

Page 1: Social Profile with Connections: Modify the Edit profile and Share profile buttons.

<img width="1551" height="823" alt="image" src="https://github.com/user-attachments/assets/76c4413d-71cd-4115-a480-1d87f3fa6bfd" />
 
Page 2: Social Profile with Card: Update follow buttons

<img width="1555" height="822" alt="image" src="https://github.com/user-attachments/assets/3a50677d-e2b3-48fa-af32-5b5e33b7a9dd" />
 
Page 3: Social Profile with Interest: 

- Move up the post, followers and following text box near profile.
- Move follow button towards right end.

<img width="1552" height="816" alt="image" src="https://github.com/user-attachments/assets/7d4230e4-9871-4eef-bcbe-4f38ccd148a7" />

Windows Demos:

https://github.com/user-attachments/assets/4c3d4b92-f187-427b-b497-fa2942a40cf0

Android Demos:
<img width="720" height="1600" alt="social profile with cards" src="https://github.com/user-attachments/assets/141ccbe5-19ff-42ca-95db-de778682519e" />
<img width="1600" height="720" alt="social profile with connections LS" src="https://github.com/user-attachments/assets/9f0cac76-64bd-41b6-8bde-24b03a2c916e" />
<img width="720" height="1600" alt="social profile with connections" src="https://github.com/user-attachments/assets/13b26c5c-3e73-4b05-a2e4-21a755625046" />
<img width="1600" height="720" alt="social profile with interest LS" src="https://github.com/user-attachments/assets/224c9b40-c706-42f0-9c54-468a2a3e5b21" />
<img width="720" height="1600" alt="social profile with interest" src="https://github.com/user-attachments/assets/ca12f0ed-9669-47c2-ad51-6f1b72170b79" />
<img width="1600" height="720" alt="social profile with cards LS" src="https://github.com/user-attachments/assets/3cf4a565-ace4-42c9-b3d0-01ca6d711076" />