### PR TITLE
Updated UI designs for first 3 Catalog pages

### DIFF
--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogListPage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogListPage.xaml
@@ -22,13 +22,13 @@
                         <VisualState x:Name="Normal">
                             <VisualState.Setters>
                                 <Setter Property="Background"
-                        Value="Transparent" />
+                                        Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                         <VisualState x:Name="PointerOver">
                             <VisualState.Setters>
                                 <Setter Property="Background"
-                        Value= "Transparent" />
+                                        Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                     </VisualStateGroup>
@@ -36,243 +36,250 @@
             </Setter>
         </Style>
         <ResourceDictionary>
-
             <!--  Header Template for Catalog SfListView  -->
             <DataTemplate x:Key="CatalogDefaultHeaderTemplate">
-                <StackLayout
-                    HorizontalOptions="End"
-                    Orientation="Horizontal"
-                    Spacing="8"
-                    VerticalOptions="Center">
-
+                <StackLayout HorizontalOptions="End"
+                             Orientation="Horizontal"
+                             Spacing="8"
+                             VerticalOptions="Center">
                     <!--  Filter Button  -->
-                    <buttons:SfButton
-                        Background="Transparent"
-                        CornerRadius="4"
-                        HeightRequest="32"
-                        WidthRequest="100"
-                        TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      HeightRequest="32"
+                                      WidthRequest="100"
+                                      TextColor="{DynamicResource Gray-700}">
                         <buttons:SfButton.Content>
                             <DataTemplate>
-                                <StackLayout
-    Padding="8,5,8,6"
-    Orientation="Horizontal"
-    Spacing="8"
-    VerticalOptions="Center">
-                                    <Label
-        FontFamily="FontIcons"
-        FontSize="18"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="{DynamicResource Filter}"
-        VerticalOptions="Center"
-        VerticalTextAlignment="End"/>
-                                    <Label
-        FontFamily="Roboto-Medium"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="Filter"
-        VerticalOptions="Center"
-        VerticalTextAlignment="Center"/>
+                                <StackLayout Padding="8,5,8,6"
+                                             Orientation="Horizontal"
+                                             Spacing="8"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Filter}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="End" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Filter"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
                                 </StackLayout>
                             </DataTemplate>
-
                         </buttons:SfButton.Content>
                     </buttons:SfButton>
 
                     <!--  Sort Button  -->
-                    <buttons:SfButton
-                        Background="Transparent"
-                        CornerRadius="4"
-                        HeightRequest="32"
-                        WidthRequest="100"
-                        TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      HeightRequest="32"
+                                      WidthRequest="100"
+                                      TextColor="{DynamicResource Gray-700}">
                         <buttons:SfButton.Content>
                             <DataTemplate>
-                                <StackLayout
-    Padding="8,5,16,6"
-    Orientation="Horizontal"
-    Spacing="8"
-    VerticalOptions="Center">
-                                    <Label
-        FontFamily="FontIcons"
-        FontSize="18"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="{DynamicResource Sort}"
-        VerticalOptions="Center"
-        VerticalTextAlignment="End"/>
-                                    <Label
-        FontFamily="Roboto-Medium"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="Sorting"
-        VerticalOptions="Center"
-        VerticalTextAlignment="Center"/>
+                                <StackLayout Padding="8,5,16,6"
+                                             Orientation="Horizontal"
+                                             Spacing="8"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Sort}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="End" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Sorting"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
                                 </StackLayout>
                             </DataTemplate>
                         </buttons:SfButton.Content>
-                        
                     </buttons:SfButton>
-
                 </StackLayout>
             </DataTemplate>
 
-            <converter:BooleanToColorConverter x:Key="boolToColorConverter"/>
-            <converter:BooleanToStringConverter x:Key="boolToStringConverter"/>
-            <converter:DynamicResourceToColorConverter x:Key="DynamicResourceToColorConverter"/>
+            <converter:BooleanToColorConverter x:Key="boolToColorConverter" />
+            <converter:BooleanToStringConverter x:Key="boolToStringConverter" />
+            <converter:DynamicResourceToColorConverter x:Key="DynamicResourceToColorConverter" />
 
         </ResourceDictionary>
     </ContentView.Resources>
 
     <ContentView.Content>
+        <Grid RowDefinitions="Auto,*"
+              ColumnSpacing="0"
+              RowSpacing="0">
+            <HorizontalStackLayout HorizontalOptions="End">
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       FontSize="18"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="{DynamicResource Search}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
 
-        <Grid
-            ColumnSpacing="0"
-            RowSpacing="0">
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       FontSize="18"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="{DynamicResource Cart}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+            </HorizontalStackLayout>
             <!--  ListView for catalog list  -->
             <listView:SfListView WidthRequest="{OnPlatform MacCatalyst=800}"
-                    BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
+                                 BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
                                  x:Name="ListViewList"
-                                 Padding="{OnIdiom Default='0,8,0,0',
-                              Desktop='15,15,15,0'}"
+                                 Grid.Row="1"
+                                 Padding="{OnIdiom Default='0,8,0,0', Desktop='15,15,15,0'}"
                                  AutoFitMode="Height"
                                  HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
                                  HorizontalOptions="Fill"
                                  IsStickyHeader="False"
                                  ItemSize="170"
-                                 ItemSpacing="0,0,0,16"
+                                 ItemSpacing="0,0,0,10"
                                  ItemsSource="{Binding Products}"
                                  Style="{DynamicResource TransparentSelectionListView}">
 
-
                 <listView:SfListView.ItemTemplate>
                     <DataTemplate x:DataType="model:Product">
-                        <syncEffectsView:SfEffectsView
-                            RippleBackground="{DynamicResource Gray-300}"
-                            TouchDownEffects="Ripple">
+                        <syncEffectsView:SfEffectsView RippleBackground="{DynamicResource Gray-300}"
+                                                       TouchDownEffects="Ripple">
                             <Border Margin="20,0,20,0"
-                                    Stroke="Transparent"
+                                    HorizontalOptions="Center"
+                                    Stroke="#e3e3e3"
+                                    StrokeThickness="2"
                                     StrokeShape="RoundRectangle 10"
-                                    HeightRequest="150">
-                                <Grid>
-                                    <Grid.Resources>
-                                        <ResourceDictionary>
-                                            <converter:BooleanToStringConverter x:Key="boolToStringConverter"/>
-                                            <converter:BooleanToColorConverter x:Key="boolToColorConverter"/>
-                                        </ResourceDictionary>
-                                    </Grid.Resources>
+                                    WidthRequest="600"
+                                    HeightRequest="140">
+                                <Border.Shadow>
+                                    <Shadow Brush="#000000"
+                                            Offset="2,2"
+                                            Radius="8"
+                                            Opacity="0.15" />
+                                </Border.Shadow>
 
-                                    <Grid
-                                        Margin="0"
-                                        ColumnSpacing="0"
-                                        HorizontalOptions="Fill"
-                                        RowDefinitions="*, *, *"
-                                        RowSpacing="0"
-                                        VerticalOptions="Fill">
+                                <Grid Margin="0"
+                                      BackgroundColor="White"
+                                      ColumnSpacing="0"
+                                      RowDefinitions="Auto, Auto, Auto"
+                                      RowSpacing="0">
 
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="{OnIdiom Default=*, Desktop=*}"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="{OnIdiom Default=*, Desktop=*}" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
 
-                                        <!--  Product Image  -->
-                                        <Image
-                                            Grid.RowSpan="3"
-                                            Aspect="AspectFill"
-                                            HeightRequest="150"
-                                            WidthRequest="133">
-                                            <Image.Source>
-                                                <UriImageSource
-                                                    CacheValidity="14"
-                                                    CachingEnabled="true"
-                                                    Uri="{Binding PreviewImage}"/>
-                                            </Image.Source>
-                                        </Image>
+                                    <!--  Product Image  -->
+                                    <Image Grid.RowSpan="3"
+                                           Aspect="AspectFill"
+                                           HeightRequest="140"
+                                           WidthRequest="133">
+                                        <Image.Source>
+                                            <UriImageSource CacheValidity="14"
+                                                            CachingEnabled="true"
+                                                            Uri="{Binding PreviewImage}" />
+                                        </Image.Source>
+                                    </Image>
 
-                                        <!--  Product Name  -->
-                                        <Label
-                                            Grid.Row="0"
-                                            Grid.Column="1"
-                                            Margin="8,15,0,4"
-                                            FontSize="14"
-                                            HorizontalOptions="Start"
-                                            LineBreakMode="TailTruncation"
-                                            MaxLines="1"
-                                            Style="{DynamicResource TitleLabelStyle}"
-                                            Text="{Binding Name}"/>
+                                    <!--  Product Name  -->
+                                    <Label Grid.Row="0"
+                                           Grid.Column="1"
+                                           Margin="8,5,0,0"
+                                           FontSize="16"
+                                           LineHeight="1"
+                                           VerticalOptions="Center"
+                                           TextColor="#6b6a6a"
+                                           LineBreakMode="TailTruncation"
+                                           MaxLines="1"
+                                           Text="{Binding Name}" />
 
-                                        <StackLayout  Grid.Column="1"
-                                                      Grid.Row="1"
-                                                      Margin="8,10,0,8"
-                                                      Orientation="Horizontal"
-                                                      Spacing="2">
-
-                                            <!--  Product Price  -->
-                                            <Label
-                                                FontFamily="Roboto-Medium"
-                                                FontSize="16"
-                                                LineHeight="{OnPlatform Android=1.25,
+                                    <StackLayout  Grid.Column="1"
+                                                  Grid.Row="1"
+                                                  Margin="8,0,0,8"
+                                                  VerticalOptions="Start"
+                                                  Orientation="Horizontal"
+                                                  Spacing="2">
+                                        <!--  Product Price  -->
+                                        <Label FontFamily="Roboto-Medium"
+                                               FontSize="16"
+                                               LineHeight="{OnPlatform Android=1.25,
                                 Default=-1}"
-                                                Style="{DynamicResource SimpleLabelStyle}"
-                                                Text="{Binding DiscountPrice, StringFormat='${0:0 }'}"/>
+                                               Style="{DynamicResource SimpleLabelStyle}"
+                                               Text="{Binding DiscountPrice, StringFormat='${0:0 }'}" />
+                                        <Label Margin="5,0,0,0"
+                                               VerticalOptions="Center"
+                                               TextColor="Gray"
+                                               Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
+                                               FontSize="12"
+                                               TextDecorations="Strikethrough" />
+                                        <Label Margin="5,0,0,0"
+                                               VerticalOptions="Center"
+                                               TextColor="Gray"
+                                               Text="(49% off)"
+                                               FontSize="12" />
 
-                                            <Label Margin="10,0,0,0"
-                                                    VerticalOptions="Center"
-                                                   Style="{DynamicResource SimpleLabelStyle}"
-                                                   Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
-                                                   FontSize="12"
-                                                   TextDecorations="Strikethrough"/>
+                                    </StackLayout>
 
+                                    <StackLayout Grid.Row="2"
+                                                 Margin="6,0,0,15"
+                                                 Orientation="Horizontal"
+                                                 Grid.Column="1">
+                                        <rating:SfRating BackgroundColor="Transparent"
+                                                         Grid.Row="3"
+                                                         Grid.Column="1"
+                                                         ItemSize="13"
+                                                         ItemSpacing="1"
+                                                         RatingSettings="{DynamicResource CommonRatingSettings}"
+                                                         Style="{DynamicResource RatingStyle}"
+                                                         Value="{Binding OverallRating}" />
+                                        <Label Margin="10,0,0,0"
+                                               Text="{Binding OverallRating}"
+                                               Style="{DynamicResource SimpleLabelStyle}" />
+                                        <Label Text="/5"
+                                               Style="{DynamicResource SimpleLabelStyle}" />
 
-                                            <Label
-                                                Margin="10,0,0,0"
-                                                    VerticalOptions="Center"
-                                                Style="{DynamicResource SimpleLabelStyle}"
-                                                Text="(49% off)"
-                                                FontSize="12"/>
+                                    </StackLayout>
 
-                                        </StackLayout>
-
-                                        <StackLayout Grid.Row="2"
-                                                     Margin="6,0,0,0"
-                                                     Orientation="Horizontal"
-                                                     Grid.Column="1">
-                                            <rating:SfRating BackgroundColor="Transparent"
-                                                             Grid.Row="3"
-                                                             Grid.Column="1"
-                                                             ItemSize="13"
-                                                             ItemSpacing="1"
-                                                             RatingSettings="{DynamicResource CommonRatingSettings}"
-                                                             Style="{DynamicResource RatingStyle}"
-                                                             Value="{Binding OverallRating}"/>
-                                            <Label Margin="10,0,0,0"
-                                                   Text="{Binding OverallRating}"
-                                                   Style="{DynamicResource SimpleLabelStyle}"/>
-                                            <Label Text="/5"
-                                                   Style="{DynamicResource SimpleLabelStyle}"/>
-
-                                        </StackLayout>
-
-                                        <!--  Favourite Icon  -->
-                                        <buttons:SfButton
-                                            Grid.Column="2"
-                                            Margin="0,5,0,8"
-                                            Padding="0"
-                                            HeightRequest="-1"
-                                            Style="{DynamicResource IconButtonStyle}"
-                                            Text="{Binding IsFavourite, Converter={StaticResource boolToStringConverter}, ConverterParameter=1}"
-                                            TextColor="{Binding IsFavourite, Converter={x:StaticResource boolToColorConverter}, ConverterParameter=4}"
-                                            Clicked="FavouriteButton_Clicked"
-                                            WidthRequest="-1"/>
-                                    </Grid>
+                                    <!--  Favourite Icon  -->
+                                    <buttons:SfButton Grid.Column="2"
+                                                      Margin="0,5,0,8"
+                                                      Padding="0"
+                                                      HeightRequest="-1"
+                                                      Style="{DynamicResource IconButtonStyle}"
+                                                      Text="{Binding IsFavourite, Converter={StaticResource boolToStringConverter}, ConverterParameter=1}"
+                                                      TextColor="{Binding IsFavourite, Converter={x:StaticResource boolToColorConverter}, ConverterParameter=4}"
+                                                      Clicked="FavouriteButton_Clicked"
+                                                      WidthRequest="-1" />
                                 </Grid>
                             </Border>
-
                         </syncEffectsView:SfEffectsView>
                     </DataTemplate>
                 </listView:SfListView.ItemTemplate>
-
             </listView:SfListView>
-
         </Grid>
-
     </ContentView.Content>
 </ContentView>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogListPage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogListPage.xaml
@@ -38,7 +38,7 @@
         <ResourceDictionary>
             <!--  Header Template for Catalog SfListView  -->
             <DataTemplate x:Key="CatalogDefaultHeaderTemplate">
-                <StackLayout HorizontalOptions="End"
+                <StackLayout HorizontalOptions="End" Margin="{OnIdiom Phone='0,0,10,0', Tablet=0, Desktop='0,0,30,0'}"
                              Orientation="Horizontal"
                              Spacing="8"
                              VerticalOptions="Center">
@@ -108,209 +108,468 @@
     </ContentView.Resources>
 
     <ContentView.Content>
-        <Grid RowDefinitions="Auto,*"
+
+        <Grid RowDefinitions="Auto,Auto,*"
               ColumnSpacing="0"
               RowSpacing="0">
-             <Grid ColumnDefinitions="Auto,*">
+            <Grid.Resources>
+                <ResourceDictionary>
+                    <converter:BooleanToStringConverter x:Key="boolToStringConverter" />
+                    <converter:BooleanToColorConverter x:Key="boolToColorConverter" />
+                </ResourceDictionary>
+            </Grid.Resources>
+            <Grid ColumnDefinitions="Auto,*"
+                  Padding="0,5,0,5">
                 <buttons:SfButton Background="Transparent"
-                                   IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                  CornerRadius="4"
+                                  Margin="{OnIdiom Desktop=0,Default=5 }"
+                                  HeightRequest="32"
+                                  WidthRequest="100"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         Orientation="Horizontal"
+                                         Spacing="8"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       Rotation="180"
+                                       FontSize="20"
+                                       IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                       Text="{DynamicResource ArrowRight}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                                <Label FontFamily="Roboto-Medium"
+                                       FontSize="16"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="Dress"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+                <HorizontalStackLayout Grid.Column="1"
+                                       Margin="5"
+                                       HorizontalOptions="End">
+                    <buttons:SfButton Background="Transparent"
                                       CornerRadius="4"
-                                      Margin="10,0,0,0"
-                                      HeightRequest="32"
-                                      WidthRequest="100"
                                       TextColor="{DynamicResource Gray-700}">
                         <buttons:SfButton.Content>
                             <DataTemplate>
                                 <StackLayout Padding="8,5,8,6"
-                                             Orientation="Horizontal"
-                                             Spacing="8"
                                              VerticalOptions="Center">
                                     <Label FontFamily="FontIcons"
-                                        Rotation="180"
-                                           FontSize="18"
-                                           Style="{DynamicResource DescriptionLabelStyle}"
-                                           Text="{DynamicResource ArrowRight}"
-                                           VerticalOptions="Center"
-                                           VerticalTextAlignment="Center" />
-                                    <Label FontFamily="Roboto-Medium"
-                                           Style="{DynamicResource DescriptionLabelStyle}"
-                                           Text="Dress"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Text="{DynamicResource Search}"
                                            VerticalOptions="Center"
                                            VerticalTextAlignment="Center" />
                                 </StackLayout>
                             </DataTemplate>
                         </buttons:SfButton.Content>
                     </buttons:SfButton>
-            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End">
-                <buttons:SfButton Background="Transparent"
-                                  CornerRadius="4"
-                                  TextColor="{DynamicResource Gray-700}">
-                    <buttons:SfButton.Content>
-                        <DataTemplate>
-                            <StackLayout Padding="8,5,8,6"
-                                         VerticalOptions="Center">
-                                <Label FontFamily="FontIcons"
-                                       FontSize="18"
-                                       Style="{DynamicResource DescriptionLabelStyle}"
-                                       Text="{DynamicResource Search}"
-                                       VerticalOptions="Center"
-                                       VerticalTextAlignment="Center" />
-                            </StackLayout>
-                        </DataTemplate>
-                    </buttons:SfButton.Content>
-                </buttons:SfButton>
 
-                <buttons:SfButton Background="Transparent"
-                                  CornerRadius="4"
-                                  TextColor="{DynamicResource Gray-700}">
-                    <buttons:SfButton.Content>
-                        <DataTemplate>
-                            <StackLayout Padding="8,5,8,6"
-                                         VerticalOptions="Center">
-                                <Label FontFamily="FontIcons"
-                                       FontSize="18"
-                                       Style="{DynamicResource DescriptionLabelStyle}"
-                                       Text="{DynamicResource Cart}"
-                                       VerticalOptions="Center"
-                                       VerticalTextAlignment="Center" />
-                            </StackLayout>
-                        </DataTemplate>
-                    </buttons:SfButton.Content>
-                </buttons:SfButton>
-            </HorizontalStackLayout>
-            </Grid>
-            <!--  ListView for catalog list  -->
-            <listView:SfListView WidthRequest="{OnPlatform MacCatalyst=800}"
-                                 BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                                 x:Name="ListViewList"
-                                 Grid.Row="1"
-                                 Padding="{OnIdiom Default='0,8,0,0', Desktop='15,15,15,0'}"
-                                 AutoFitMode="Height"
-                                 HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
-                                 HorizontalOptions="Fill"
-                                 IsStickyHeader="False"
-                                 ItemSize="170"
-                                 ItemSpacing="0,0,0,10"
-                                 ItemsSource="{Binding Products}"
-                                 Style="{DynamicResource TransparentSelectionListView}">
-
-                <listView:SfListView.ItemTemplate>
-                    <DataTemplate x:DataType="model:Product">
-                        <syncEffectsView:SfEffectsView RippleBackground="{DynamicResource Gray-300}"
-                                                       TouchDownEffects="Ripple">
-                            <Border Margin="20,0,20,0"
-                                    HorizontalOptions="Center"
-                                    Stroke="#e3e3e3"
-                                    StrokeThickness="2"
-                                    StrokeShape="RoundRectangle 10"
-                                    WidthRequest="{OnIdiom Phone=385, Tablet=528, Desktop=600}"
-                                    HeightRequest="140">
-                                <Border.Shadow>
-                                    <Shadow Brush="#000000"
-                                            Offset="2,2"
-                                            Radius="8"
-                                            Opacity="0.15" />
-                                </Border.Shadow>
-
-                                <Grid Margin="0"
-                                      BackgroundColor="White"
-                                      ColumnSpacing="0"
-                                      RowDefinitions="Auto, Auto, Auto"
-                                      RowSpacing="0">
-
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="{OnIdiom Default=*, Desktop=*}" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <!--  Product Image  -->
-                                    <Image Grid.RowSpan="3"
-                                           Aspect="AspectFill"
-                                           HeightRequest="140"
-                                           WidthRequest="133">
-                                        <Image.Source>
-                                            <UriImageSource CacheValidity="14"
-                                                            CachingEnabled="true"
-                                                            Uri="{Binding PreviewImage}" />
-                                        </Image.Source>
-                                    </Image>
-
-                                    <!--  Product Name  -->
-                                    <Label Grid.Row="0"
-                                           Grid.Column="1"
-                                           Margin="8,5,0,0"
-                                           FontSize="16"
-                                           LineHeight="1"
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Text="{DynamicResource Cart}"
                                            VerticalOptions="Center"
-                                           TextColor="#6b6a6a"
-                                           LineBreakMode="TailTruncation"
-                                           MaxLines="1"
-                                           Text="{Binding Name}" />
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </HorizontalStackLayout>
+            </Grid>
+            <BoxView HeightRequest="1"
+                     Grid.Row="1"
+                     Color="#E5E1E3" />
 
-                                    <StackLayout  Grid.Column="1"
-                                                  Grid.Row="1"
-                                                  Margin="8,0,0,8"
-                                                  VerticalOptions="Start"
-                                                  Orientation="Horizontal"
-                                                  Spacing="2">
-                                        <!--  Product Price  -->
-                                        <Label FontFamily="Roboto-Medium"
-                                               FontSize="16"
-                                               LineHeight="{OnPlatform Android=1.25,
-                                Default=-1}"
-                                               Style="{DynamicResource SimpleLabelStyle}"
-                                               Text="{Binding DiscountPrice, StringFormat='${0:0 }'}" />
-                                        <Label Margin="5,0,0,0"
-                                               VerticalOptions="Center"
-                                               TextColor="Gray"
-                                               Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
-                                               FontSize="12"
-                                               TextDecorations="Strikethrough" />
-                                        <Label Margin="5,0,0,0"
-                                               VerticalOptions="Center"
-                                               TextColor="Gray"
-                                               Text="(49% off)"
-                                               FontSize="12" />
+            <Grid Grid.Row="2"
+                  RowDefinitions="*,Auto"
+                  ColumnDefinitions="Auto,Auto,*">
 
-                                    </StackLayout>
+                <StackLayout Spacing="{OnIdiom Tablet=40, Desktop=35}"
+                             Grid.Column="0"
+                             Grid.Row="0"
+                             Margin="{OnIdiom Tablet='10,0,10,0', Desktop='0,0,20,0'}"
+                             IsVisible="{OnIdiom Phone=False, Tablet=True, Desktop=True}">
+                    <buttons:SfButton Background="Transparent"
+                                      Margin="0,20,0,0"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Text="{DynamicResource Home}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           TextColor="#7633DA"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Category}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                                    <StackLayout Grid.Row="2"
-                                                 Margin="6,0,0,15"
-                                                 Orientation="Horizontal"
-                                                 Grid.Column="1">
-                                        <rating:SfRating BackgroundColor="Transparent"
-                                                         Grid.Row="3"
-                                                         Grid.Column="1"
-                                                         ItemSize="13"
-                                                         ItemSpacing="1"
-                                                         RatingSettings="{DynamicResource CommonRatingSettings}"
-                                                         Style="{DynamicResource RatingStyle}"
-                                                         Value="{Binding OverallRating}" />
-                                        <Label Margin="10,0,0,0"
-                                               Text="{Binding OverallRating}"
-                                               Style="{DynamicResource SimpleLabelStyle}" />
-                                        <Label Text="/5"
-                                               Style="{DynamicResource SimpleLabelStyle}" />
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                                    </StackLayout>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Settings}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                                    <!--  Favourite Icon  -->
-                                    <buttons:SfButton Grid.Column="2"
-                                                      Margin="0,5,0,8"
-                                                      Padding="0"
-                                                      HeightRequest="-1"
-                                                      Style="{DynamicResource IconButtonStyle}"
-                                                      Text="{Binding IsFavourite, Converter={StaticResource boolToStringConverter}, ConverterParameter=1}"
-                                                      TextColor="{Binding IsFavourite, Converter={x:StaticResource boolToColorConverter}, ConverterParameter=4}"
-                                                      Clicked="FavouriteButton_Clicked"
-                                                      WidthRequest="-1" />
-                                </Grid>
-                            </Border>
-                        </syncEffectsView:SfEffectsView>
-                    </DataTemplate>
-                </listView:SfListView.ItemTemplate>
-            </listView:SfListView>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Account}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </StackLayout>
+
+                <BoxView WidthRequest="1"
+                         Grid.Row="0"
+                         Grid.Column="1"
+                         IsVisible="{OnIdiom Phone=False, Tablet=True, Desktop=True}"
+                         Color="#E5E1E3" />
+                <!--  ListView for catalog  -->
+                <ScrollView Grid.Column="2" Padding="0"
+                            Grid.Row="0">
+
+                    <VerticalStackLayout>
+                        <!--  ListView for catalog list  -->
+                        <listView:SfListView WidthRequest="{OnPlatform MacCatalyst=800}"
+                                             BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
+                                             x:Name="ListViewList"
+                                             Grid.Row="1"
+                                             Padding="{OnIdiom Default='0,8,0,0', Desktop='0,0,20,0'}"
+                                             AutoFitMode="Height"
+                                             HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
+                                             HorizontalOptions="Fill"
+                                             HeightRequest="{OnPlatform Android=800, MacCatalyst=900, WinUI=700, iOS=800}"
+                                             IsStickyHeader="False"
+                                             ItemSize="170"
+                                             ItemSpacing="0,0,0,10"
+                                             ItemsSource="{Binding Products}"
+                                             Style="{DynamicResource TransparentSelectionListView}">
+
+                            <listView:SfListView.ItemTemplate>
+                                <DataTemplate x:DataType="model:Product">
+                                    <syncEffectsView:SfEffectsView RippleBackground="{DynamicResource Gray-300}"
+                                                                   TouchDownEffects="Ripple">
+                                        <Border Margin="20,0,20,0"
+                                                HorizontalOptions="Center"
+                                                Stroke="#e3e3e3"
+                                                StrokeThickness="2"
+                                                StrokeShape="RoundRectangle 10"
+                                                WidthRequest="{OnIdiom Phone=390, Tablet=528, Desktop=600}"
+                                                HeightRequest="140">
+                                            <Border.Shadow>
+                                                <Shadow Brush="#000000"
+                                                        Offset="2,2"
+                                                        Radius="8"
+                                                        Opacity="0.15" />
+                                            </Border.Shadow>
+
+                                            <Grid Margin="0"
+                                                  BackgroundColor="White"
+                                                  ColumnSpacing="0"
+                                                  RowDefinitions="Auto, Auto, Auto"
+                                                  RowSpacing="0">
+
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="{OnIdiom Default=*, Desktop=*}" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <!--  Product Image  -->
+                                                <Image Grid.RowSpan="3"
+                                                       Aspect="AspectFill"
+                                                       HeightRequest="140"
+                                                       WidthRequest="133">
+                                                    <Image.Source>
+                                                        <UriImageSource CacheValidity="14"
+                                                                        CachingEnabled="true"
+                                                                        Uri="{Binding PreviewImage}" />
+                                                    </Image.Source>
+                                                </Image>
+
+                                                <!--  Product Name  -->
+                                                <Label Grid.Row="0"
+                                                       Grid.Column="1"
+                                                       Margin="8,5,0,0"
+                                                       FontSize="16"
+                                                       LineHeight="1"
+                                                       VerticalOptions="Center"
+                                                       TextColor="#6b6a6a"
+                                                       LineBreakMode="TailTruncation"
+                                                       MaxLines="1"
+                                                       Text="{Binding Name}" />
+
+                                                <StackLayout  Grid.Column="1"
+                                                              Grid.Row="1"
+                                                              Margin="8,0,0,8"
+                                                              VerticalOptions="Start"
+                                                              Orientation="Horizontal"
+                                                              Spacing="2">
+                                                    <!--  Product Price  -->
+                                                    <Label FontFamily="Roboto-Medium"
+                                                           FontSize="16"
+                                                           LineHeight="{OnPlatform Android=1.25,
+	                             Default=-1}"
+                                                           Style="{DynamicResource SimpleLabelStyle}"
+                                                           Text="{Binding DiscountPrice, StringFormat='${0:0 }'}" />
+                                                    <Label Margin="5,0,0,0"
+                                                           VerticalOptions="Center"
+                                                           TextColor="Gray"
+                                                           Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
+                                                           FontSize="12"
+                                                           TextDecorations="Strikethrough" />
+                                                    <Label Margin="5,0,0,0"
+                                                           VerticalOptions="Center"
+                                                           TextColor="Gray"
+                                                           Text="(49% off)"
+                                                           FontSize="12" />
+
+                                                </StackLayout>
+
+                                                <StackLayout Grid.Row="2"
+                                                             Margin="6,0,0,15"
+                                                             Orientation="Horizontal"
+                                                             Grid.Column="1">
+                                                    <rating:SfRating BackgroundColor="Transparent"
+                                                                     Grid.Row="3"
+                                                                     Grid.Column="1"
+                                                                     ItemSize="13"
+                                                                     ItemSpacing="1"
+                                                                     RatingSettings="{DynamicResource CommonRatingSettings}"
+                                                                     Style="{DynamicResource RatingStyle}"
+                                                                     Value="{Binding OverallRating}" />
+                                                    <Label Margin="10,0,0,0"
+                                                           Text="{Binding OverallRating}"
+                                                           Style="{DynamicResource SimpleLabelStyle}" />
+                                                    <Label Text="/5"
+                                                           Style="{DynamicResource SimpleLabelStyle}" />
+
+                                                </StackLayout>
+
+                                                <!--  Favourite Icon  -->
+                                                <buttons:SfButton Grid.Column="2"
+                                                                  Margin="0,5,0,8"
+                                                                  Padding="0"
+                                                                  HeightRequest="-1"
+                                                                  Style="{DynamicResource IconButtonStyle}"
+                                                                  Text="{Binding IsFavourite, Converter={StaticResource boolToStringConverter}, ConverterParameter=1}"
+                                                                  TextColor="{Binding IsFavourite, Converter={x:StaticResource boolToColorConverter}, ConverterParameter=4}"
+                                                                  Clicked="FavouriteButton_Clicked"
+                                                                  WidthRequest="-1" />
+                                            </Grid>
+                                        </Border>
+                                    </syncEffectsView:SfEffectsView>
+                                </DataTemplate>
+                            </listView:SfListView.ItemTemplate>
+                        </listView:SfListView>
+                    </VerticalStackLayout>
+                </ScrollView>
+               <StackLayout Spacing="25"
+                             Padding="5"
+                             Grid.Row="1"
+                             Grid.Column="2"
+                             Orientation="Horizontal"
+                             IsVisible="{OnIdiom Phone=True, Tablet=False, Desktop=False}">
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Home}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Text="Home"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           TextColor="#7633DA"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Category}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Categories"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Cart"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Settings}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Settings"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Account}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                                TextColor="#5F5E60"
+                                           Text="Account"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </StackLayout>
+            </Grid>
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogListPage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogListPage.xaml
@@ -111,7 +111,37 @@
         <Grid RowDefinitions="Auto,*"
               ColumnSpacing="0"
               RowSpacing="0">
-            <HorizontalStackLayout HorizontalOptions="End">
+             <Grid ColumnDefinitions="Auto,*">
+                <buttons:SfButton Background="Transparent"
+                                   IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                      CornerRadius="4"
+                                      Margin="10,0,0,0"
+                                      HeightRequest="32"
+                                      WidthRequest="100"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             Orientation="Horizontal"
+                                             Spacing="8"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                        Rotation="180"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource ArrowRight}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Dress"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End">
                 <buttons:SfButton Background="Transparent"
                                   CornerRadius="4"
                                   TextColor="{DynamicResource Gray-700}">
@@ -148,6 +178,7 @@
                     </buttons:SfButton.Content>
                 </buttons:SfButton>
             </HorizontalStackLayout>
+            </Grid>
             <!--  ListView for catalog list  -->
             <listView:SfListView WidthRequest="{OnPlatform MacCatalyst=800}"
                                  BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
@@ -172,7 +203,7 @@
                                     Stroke="#e3e3e3"
                                     StrokeThickness="2"
                                     StrokeShape="RoundRectangle 10"
-                                    WidthRequest="600"
+                                    WidthRequest="{OnIdiom Phone=385, Tablet=528, Desktop=600}"
                                     HeightRequest="140">
                                 <Border.Shadow>
                                     <Shadow Brush="#000000"

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogTilePage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogTilePage.xaml
@@ -13,7 +13,7 @@
              x:DataType="local:CartPageViewModel">
 
     <ContentView.BindingContext>
-        <local:CartPageViewModel/>
+        <local:CartPageViewModel />
     </ContentView.BindingContext>
     <ContentView.Resources>
         <Style TargetType="listView:ListViewItem">
@@ -23,13 +23,13 @@
                         <VisualState x:Name="Normal">
                             <VisualState.Setters>
                                 <Setter Property="Background"
-                        Value="Transparent" />
+                                        Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                         <VisualState x:Name="PointerOver">
                             <VisualState.Setters>
                                 <Setter Property="Background"
-                        Value= "Transparent" />
+                                        Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                     </VisualStateGroup>
@@ -39,226 +39,236 @@
         <ResourceDictionary>
 
             <OnIdiom x:Key="ListItemMargin"
-                     x:TypeArguments="Thickness"/>
-            <converter:BooleanToColorConverter x:Key="BoolToColorConverter"/>
-            <converter:BooleanToStringConverter x:Key="BoolToStringConverter"/>
-            <converter:DynamicResourceToColorConverter x:Key="DynamicResourceToColorConverter"/>
+                     x:TypeArguments="Thickness" />
+            <converter:BooleanToColorConverter x:Key="BoolToColorConverter" />
+            <converter:BooleanToStringConverter x:Key="BoolToStringConverter" />
+            <converter:DynamicResourceToColorConverter x:Key="DynamicResourceToColorConverter" />
 
             <!--  Header Template for Catalog SfListView  -->
             <DataTemplate x:Key="CatalogDefaultHeaderTemplate">
-                <StackLayout
-                    HorizontalOptions="End"
-                    Orientation="Horizontal"
-                    Spacing="8"
-                    VerticalOptions="Center">
+                <StackLayout HorizontalOptions="End"
+                             Orientation="Horizontal"
+                             Spacing="8"
+                             VerticalOptions="Center">
 
-                      <!--Filter Button-->  
-                    <buttons:SfButton
-                        Background="Transparent"
-                        CornerRadius="4"
-                        HeightRequest="32"
-                        WidthRequest="100"
-                        TextColor="{DynamicResource Gray-700}">
+                    <!--Filter Button-->
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      HeightRequest="32"
+                                      WidthRequest="100"
+                                      TextColor="{DynamicResource Gray-700}">
                         <buttons:SfButton.Content>
                             <DataTemplate>
-                                <StackLayout
-    Padding="8,5,8,6"
-    Orientation="Horizontal"
-    Spacing="8"
-    VerticalOptions="Center">
-                                    <Label
-        FontFamily="FontIcons"
-        FontSize="18"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="{DynamicResource Filter}"
-        VerticalOptions="Center"
-        VerticalTextAlignment="Center"/>
-                                    <Label
-        FontFamily="Roboto-Medium"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="Filter"
-        VerticalOptions="Center"
-        VerticalTextAlignment="Center"/>
-                                </StackLayout>
-                            </DataTemplate>
-                        </buttons:SfButton.Content>
-                        
-                    </buttons:SfButton>
-
-                      <!--Sort Button-->  
-                    <buttons:SfButton
-                        Background="Transparent"
-                        CornerRadius="4"
-                        HeightRequest="32"
-                        WidthRequest="100"
-                        TextColor="{DynamicResource Gray-700}">
-                        <buttons:SfButton.Content>
-                            <DataTemplate>
-                                <StackLayout
-    Padding="8,5,8,6"
-    Orientation="Horizontal"
-    VerticalOptions="Center"
-    Spacing="8">
-                                    <Label
-        FontFamily="FontIcons"
-        FontSize="18"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="{DynamicResource Sort}"
-        VerticalOptions="Center"
-        VerticalTextAlignment="End"/>
-                                    <Label
-        FontFamily="Roboto-Medium"
-        Style="{DynamicResource DescriptionLabelStyle}"
-        Text="Sorting"
-        VerticalOptions="Center"
-        VerticalTextAlignment="Center"/>
+                                <StackLayout Padding="8,5,8,6"
+                                             Orientation="Horizontal"
+                                             Spacing="8"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Filter}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Filter"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
                                 </StackLayout>
                             </DataTemplate>
                         </buttons:SfButton.Content>
                     </buttons:SfButton>
 
+                    <!--Sort Button-->
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      HeightRequest="32"
+                                      WidthRequest="100"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center"
+                                             Spacing="8">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Sort}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="End" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Sorting"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
                 </StackLayout>
             </DataTemplate>
-
         </ResourceDictionary>
     </ContentView.Resources>
 
     <ContentView.Content>
 
-        <Grid
-            ColumnSpacing="0"
-            RowSpacing="0">
+        <Grid RowDefinitions="Auto,*"
+              ColumnSpacing="0"
+              RowSpacing="0">
+            <Grid.Resources>
+                <ResourceDictionary>
+                    <converter:BooleanToStringConverter x:Key="boolToStringConverter" />
+                    <converter:BooleanToColorConverter x:Key="boolToColorConverter" />
+                </ResourceDictionary>
+            </Grid.Resources>
+
+            <HorizontalStackLayout HorizontalOptions="End">
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       FontSize="18"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="{DynamicResource Search}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       FontSize="18"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="{DynamicResource Cart}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+            </HorizontalStackLayout>
             <!--  ListView for catalog  -->
             <listView:SfListView BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
                                  x:Name="ListViewTile"
+                                 Grid.Row="1"
                                  Padding="8"
                                  AutoFitMode="Height"
                                  HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
                                  HorizontalOptions="Fill"
                                  IsStickyHeader="False"
-                                 ItemSpacing="0, 8, 8, 8"
+                                 ItemSpacing="10"
                                  ItemsSource="{Binding Products}"
                                  Style="{DynamicResource TransparentSelectionListView}">
 
-
                 <listView:SfListView.ItemTemplate>
                     <DataTemplate x:DataType="model:Product">
-                        <syncEffectsView:SfEffectsView
-                            RippleBackground="{DynamicResource Gray-300}"
-                            TouchDownEffects="Ripple">
-                            <Grid>
-                                <Grid.Resources>
-                                    <ResourceDictionary>
-                                        <converter:BooleanToStringConverter x:Key="boolToStringConverter"/>
-                                        <converter:BooleanToColorConverter x:Key="boolToColorConverter"/>
-                                    </ResourceDictionary>
-                                </Grid.Resources>
+                        <syncEffectsView:SfEffectsView RippleBackground="{DynamicResource Gray-300}"
+                                                       TouchDownEffects="Ripple">
+                            <Border Stroke="#e3e3e3"
+                                    StrokeThickness="2"
+                                    StrokeShape="RoundRectangle 10"
+                                    WidthRequest="178"
+                                    HeightRequest="245">
+                                <Border.Shadow>
+                                    <Shadow Brush="#000000"
+                                            Offset="2,2"
+                                            Radius="8"
+                                            Opacity="0.15" />
+                                </Border.Shadow>
 
-                                <Border Stroke="Transparent"
-                                        StrokeShape="RoundRectangle 10"
-                                        WidthRequest="178"
-                                        HeightRequest="280">
-                                    <Grid
-                                        Margin="0"
-                                        RowDefinitions="Auto, Auto, Auto, Auto"
-                                        RowSpacing="0">
+                                <Grid Margin="0"
+                                      BackgroundColor="White"
+                                      RowDefinitions="Auto, Auto, Auto, Auto"
+                                      RowSpacing="0">
 
-                                        <!--  Product Image  -->
-                                        <Image
-                                            Grid.Row="0"
-                                            Margin="0,0,0,8"
-                                            BackgroundColor="{DynamicResource Gray-200}"
-                                            HeightRequest="180"
-                                            Aspect="Fill"
-                                            HorizontalOptions="{OnPlatform Android=Fill, iOS=Fill, WinUI=Fill}"
-                                            WidthRequest="{OnIdiom Phone=183,
-                           Tablet=224,
-                           Desktop=178}">
-                                            <Image.Source>
-                                                <UriImageSource
-                                                    CacheValidity="14"
-                                                    CachingEnabled="true"
-                                                    Uri="{Binding PreviewImage}"/>
-                                            </Image.Source>
-                                        </Image>
+                                    <!--  Product Image  -->
+                                    <Image Grid.Row="0"
+                                           Margin="0,0,0,8"
+                                           BackgroundColor="{DynamicResource Gray-200}"
+                                           HeightRequest="150"
+                                           Aspect="Fill"
+                                           HorizontalOptions="{OnPlatform Android=Fill, iOS=Fill, WinUI=Fill}"
+                                           WidthRequest="{OnIdiom Phone=183, Tablet=224, Desktop=178}">
+                                        <Image.Source>
+                                            <UriImageSource CacheValidity="14"
+                                                            CachingEnabled="true"
+                                                            Uri="{Binding PreviewImage}" />
+                                        </Image.Source>
+                                    </Image>
 
-                                        <!--  Product Name  -->
-                                        <Label
-                                            Grid.Row="1"
-                                            Margin="8,0,0,4"
-                                            FontSize="14"
-                                            HorizontalOptions="Start"
-                                            LineBreakMode="TailTruncation"
-                                            MaxLines="1"
-                                            Style="{DynamicResource TitleLabelStyle}"
-                                            Text="{Binding Name}"/>
+                                    <!--  Product Name  -->
+                                    <Label Grid.Row="1"
+                                           Margin="10,0,0,4"
+                                           FontSize="14"
+                                           TextColor="#6b6a6a"
+                                           HorizontalOptions="Start"
+                                           LineBreakMode="TailTruncation"
+                                           MaxLines="1"
+                                           Text="{Binding Name}" />
 
-                                        <StackLayout
-                                            Grid.Row="2"
-                                            Margin="8,0,0,8"
-                                            Orientation="Horizontal"
-                                            Spacing="2">
-
-                                            <!--  Product Price  -->
-                                            <Label
-                                                FontFamily="Roboto-Medium"
-                                                FontSize="16"
-                                                LineHeight="{OnPlatform Android=1.25,
+                                    <StackLayout Grid.Row="2"
+                                                 Margin="10,0,0,4"
+                                                 Orientation="Horizontal"
+                                                 Spacing="2">
+                                        <!--  Product Price  -->
+                                        <Label FontFamily="Roboto-Medium"
+                                               FontSize="16"
+                                               LineHeight="{OnPlatform Android=1.25,
                                 Default=-1}"
-                                                Style="{DynamicResource SimpleLabelStyle}"
-                                                Text="{Binding DiscountPrice, StringFormat='${0:0 }'}"/>
+                                               Style="{DynamicResource SimpleLabelStyle}"
+                                               Text="{Binding DiscountPrice, StringFormat='${0:0 }'}" />
+                                        <Label Margin="5,6,0,6"
+                                               TextColor="Gray"
+                                               Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
+                                               FontSize="12"
+                                               TextDecorations="Strikethrough" />
+                                        <Label Margin="10,6,0,6"
+                                               TextColor="Gray"
+                                               Text="(49% off)"
+                                               FontSize="12" />
+                                    </StackLayout>
 
-                                            <Label
-                                                Margin="5,6,0,6"
-                                                Style="{DynamicResource SimpleLabelStyle}"
-                                                Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
-                                                FontSize="12"
-                                                TextDecorations="Strikethrough"/>
-
-
-                                            <Label
-                                                Margin="10,6,0,6"
-                                                Style="{DynamicResource SimpleLabelStyle}"
-                                                Text="(49% off)"
-                                                FontSize="12"/>
-
-                                        </StackLayout>
-
-                                        <StackLayout Grid.Row="3"
-                                                     Margin="6,0,0,0"
-                                                     Orientation="Horizontal">
-                                            <rating:SfRating BackgroundColor="Transparent"
-                                                             Grid.Row="3"
-                                                             Grid.Column="1"
-                                                             ItemSize="13"
-                                                             ItemSpacing="1"
-                                                             RatingSettings="{DynamicResource CommonRatingSettings}"
-                                                             Style="{DynamicResource RatingStyle}"
-                                                             Value="{Binding OverallRating}"/>
-                                            <Label Margin="10,0,0,0"
-                                                   Text="{Binding OverallRating}"
-                                                   Style="{DynamicResource SimpleLabelStyle}"/>
-                                            <Label Text="/5"
-                                                   Style="{DynamicResource SimpleLabelStyle}"/>
-
-                                        </StackLayout>
-
-                                    </Grid>
-                                </Border>
-
-
-                            </Grid>
+                                    <StackLayout Grid.Row="3"
+                                                 Margin="10,0,0,0"
+                                                 Orientation="Horizontal">
+                                        <rating:SfRating BackgroundColor="Transparent"
+                                                         Grid.Row="3"
+                                                         Grid.Column="1"
+                                                         ItemSize="13"
+                                                         ItemSpacing="1"
+                                                         RatingSettings="{DynamicResource CommonRatingSettings}"
+                                                         Style="{DynamicResource RatingStyle}"
+                                                         Value="{Binding OverallRating}" />
+                                        <Label Margin="10,0,0,0"
+                                               Text="{Binding OverallRating}"
+                                               Style="{DynamicResource SimpleLabelStyle}" />
+                                        <Label Text="/5"
+                                               Style="{DynamicResource SimpleLabelStyle}" />
+                                    </StackLayout>
+                                </Grid>
+                            </Border>
                         </syncEffectsView:SfEffectsView>
                     </DataTemplate>
                 </listView:SfListView.ItemTemplate>
 
                 <!--  Layout to customize number of columns in SfListView  -->
                 <listView:SfListView.ItemsLayout>
-                    <listView:GridLayout SpanCount="{OnPlatform Default=5, Android=2, iOS=2}"/>
+                    <listView:GridLayout SpanCount="{OnPlatform Default=4, Android=2, iOS=2}" />
                 </listView:SfListView.ItemsLayout>
-
             </listView:SfListView>
-
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogTilePage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogTilePage.xaml
@@ -122,8 +122,37 @@
                     <converter:BooleanToColorConverter x:Key="boolToColorConverter" />
                 </ResourceDictionary>
             </Grid.Resources>
-
-            <HorizontalStackLayout HorizontalOptions="End">
+<Grid ColumnDefinitions="Auto,*">
+     <buttons:SfButton Background="Transparent"
+                                   IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                      CornerRadius="4"
+                                      Margin="10,0,0,0"
+                                      HeightRequest="32"
+                                      WidthRequest="100"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             Orientation="Horizontal"
+                                             Spacing="8"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                        Rotation="180"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource ArrowRight}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Dress"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End">
                 <buttons:SfButton Background="Transparent"
                                   CornerRadius="4"
                                   TextColor="{DynamicResource Gray-700}">
@@ -160,6 +189,7 @@
                     </buttons:SfButton.Content>
                 </buttons:SfButton>
             </HorizontalStackLayout>
+            </Grid>
             <!--  ListView for catalog  -->
             <listView:SfListView BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
                                  x:Name="ListViewTile"
@@ -169,7 +199,7 @@
                                  HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
                                  HorizontalOptions="Fill"
                                  IsStickyHeader="False"
-                                 ItemSpacing="10"
+                                 ItemSpacing="{OnIdiom Phone=5, Tablet=10, Desktop=10}"
                                  ItemsSource="{Binding Products}"
                                  Style="{DynamicResource TransparentSelectionListView}">
 
@@ -180,7 +210,7 @@
                             <Border Stroke="#e3e3e3"
                                     StrokeThickness="2"
                                     StrokeShape="RoundRectangle 10"
-                                    WidthRequest="178"
+                                    WidthRequest="{OnIdiom Phone=188, Tablet=188, Desktop=178}"
                                     HeightRequest="245">
                                 <Border.Shadow>
                                     <Shadow Brush="#000000"
@@ -266,7 +296,7 @@
 
                 <!--  Layout to customize number of columns in SfListView  -->
                 <listView:SfListView.ItemsLayout>
-                    <listView:GridLayout SpanCount="{OnPlatform Default=4, Android=2, iOS=2}" />
+                    <listView:GridLayout SpanCount="{OnIdiom Phone=2, Tablet=4, Desktop=4}" />
                 </listView:SfListView.ItemsLayout>
             </listView:SfListView>
         </Grid>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogTilePage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CatalogTilePage.xaml
@@ -48,6 +48,7 @@
             <DataTemplate x:Key="CatalogDefaultHeaderTemplate">
                 <StackLayout HorizontalOptions="End"
                              Orientation="Horizontal"
+                             Margin="{OnIdiom Phone=0, Tablet=0, Desktop='0,0,30,0'}"
                              Spacing="8"
                              VerticalOptions="Center">
 
@@ -113,7 +114,7 @@
 
     <ContentView.Content>
 
-        <Grid RowDefinitions="Auto,*"
+        <Grid RowDefinitions="Auto,Auto,*"
               ColumnSpacing="0"
               RowSpacing="0">
             <Grid.Resources>
@@ -122,183 +123,431 @@
                     <converter:BooleanToColorConverter x:Key="boolToColorConverter" />
                 </ResourceDictionary>
             </Grid.Resources>
-<Grid ColumnDefinitions="Auto,*">
-     <buttons:SfButton Background="Transparent"
-                                   IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+            <Grid ColumnDefinitions="Auto,*" Padding="0,5,0,5">
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  Margin="{OnIdiom Desktop=0,Default=5}"
+                                  HeightRequest="32"
+                                  WidthRequest="110"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         Orientation="Horizontal"
+                                         Spacing="8"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       Rotation="180"
+                                       FontSize="20"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                       Text="{DynamicResource ArrowRight}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                                <Label FontFamily="Roboto-Medium"
+                                       FontSize="16"
+                                       Text="Dress"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+                <HorizontalStackLayout Grid.Column="1"
+                                       Margin="5"
+                                       HorizontalOptions="End">
+                    <buttons:SfButton Background="Transparent"
                                       CornerRadius="4"
-                                      Margin="10,0,0,0"
-                                      HeightRequest="32"
-                                      WidthRequest="100"
                                       TextColor="{DynamicResource Gray-700}">
                         <buttons:SfButton.Content>
                             <DataTemplate>
                                 <StackLayout Padding="8,5,8,6"
-                                             Orientation="Horizontal"
-                                             Spacing="8"
                                              VerticalOptions="Center">
                                     <Label FontFamily="FontIcons"
-                                        Rotation="180"
-                                           FontSize="18"
-                                           Style="{DynamicResource DescriptionLabelStyle}"
-                                           Text="{DynamicResource ArrowRight}"
-                                           VerticalOptions="Center"
-                                           VerticalTextAlignment="Center" />
-                                    <Label FontFamily="Roboto-Medium"
-                                           Style="{DynamicResource DescriptionLabelStyle}"
-                                           Text="Dress"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Text="{DynamicResource Search}"
                                            VerticalOptions="Center"
                                            VerticalTextAlignment="Center" />
                                 </StackLayout>
                             </DataTemplate>
                         </buttons:SfButton.Content>
                     </buttons:SfButton>
-            <HorizontalStackLayout Grid.Column="1" HorizontalOptions="End">
-                <buttons:SfButton Background="Transparent"
-                                  CornerRadius="4"
-                                  TextColor="{DynamicResource Gray-700}">
-                    <buttons:SfButton.Content>
-                        <DataTemplate>
-                            <StackLayout Padding="8,5,8,6"
-                                         VerticalOptions="Center">
-                                <Label FontFamily="FontIcons"
-                                       FontSize="18"
-                                       Style="{DynamicResource DescriptionLabelStyle}"
-                                       Text="{DynamicResource Search}"
-                                       VerticalOptions="Center"
-                                       VerticalTextAlignment="Center" />
-                            </StackLayout>
-                        </DataTemplate>
-                    </buttons:SfButton.Content>
-                </buttons:SfButton>
 
-                <buttons:SfButton Background="Transparent"
-                                  CornerRadius="4"
-                                  TextColor="{DynamicResource Gray-700}">
-                    <buttons:SfButton.Content>
-                        <DataTemplate>
-                            <StackLayout Padding="8,5,8,6"
-                                         VerticalOptions="Center">
-                                <Label FontFamily="FontIcons"
-                                       FontSize="18"
-                                       Style="{DynamicResource DescriptionLabelStyle}"
-                                       Text="{DynamicResource Cart}"
-                                       VerticalOptions="Center"
-                                       VerticalTextAlignment="Center" />
-                            </StackLayout>
-                        </DataTemplate>
-                    </buttons:SfButton.Content>
-                </buttons:SfButton>
-            </HorizontalStackLayout>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </HorizontalStackLayout>
             </Grid>
-            <!--  ListView for catalog  -->
-            <listView:SfListView BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                                 x:Name="ListViewTile"
-                                 Grid.Row="1"
-                                 Padding="8"
-                                 AutoFitMode="Height"
-                                 HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
-                                 HorizontalOptions="Fill"
-                                 IsStickyHeader="False"
-                                 ItemSpacing="{OnIdiom Phone=5, Tablet=10, Desktop=10}"
-                                 ItemsSource="{Binding Products}"
-                                 Style="{DynamicResource TransparentSelectionListView}">
+            <BoxView HeightRequest="1"
+                     Grid.Row="1"
+                     Color="#E5E1E3" />
 
-                <listView:SfListView.ItemTemplate>
-                    <DataTemplate x:DataType="model:Product">
-                        <syncEffectsView:SfEffectsView RippleBackground="{DynamicResource Gray-300}"
-                                                       TouchDownEffects="Ripple">
-                            <Border Stroke="#e3e3e3"
-                                    StrokeThickness="2"
-                                    StrokeShape="RoundRectangle 10"
-                                    WidthRequest="{OnIdiom Phone=188, Tablet=188, Desktop=178}"
-                                    HeightRequest="245">
-                                <Border.Shadow>
-                                    <Shadow Brush="#000000"
-                                            Offset="2,2"
-                                            Radius="8"
-                                            Opacity="0.15" />
-                                </Border.Shadow>
+            <Grid Grid.Row="2" RowDefinitions="*,Auto" ColumnDefinitions="Auto,Auto,*">
 
-                                <Grid Margin="0"
-                                      BackgroundColor="White"
-                                      RowDefinitions="Auto, Auto, Auto, Auto"
-                                      RowSpacing="0">
+                <StackLayout Spacing="{OnIdiom Tablet=40, Desktop=35}"
+                             Grid.Column="0"
+                             Grid.Row="0"
+                             Margin="{OnIdiom Tablet='10,0,10,0', Desktop='0,0,20,0'}"
+                             IsVisible="{OnIdiom Phone=False, Tablet=True, Desktop=True}">
+                    <buttons:SfButton Background="Transparent"
+                                      Margin="0,20,0,0"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Home}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           TextColor="#7633DA"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Category}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                                    <!--  Product Image  -->
-                                    <Image Grid.Row="0"
-                                           Margin="0,0,0,8"
-                                           BackgroundColor="{DynamicResource Gray-200}"
-                                           HeightRequest="150"
-                                           Aspect="Fill"
-                                           HorizontalOptions="{OnPlatform Android=Fill, iOS=Fill, WinUI=Fill}"
-                                           WidthRequest="{OnIdiom Phone=183, Tablet=224, Desktop=178}">
-                                        <Image.Source>
-                                            <UriImageSource CacheValidity="14"
-                                                            CachingEnabled="true"
-                                                            Uri="{Binding PreviewImage}" />
-                                        </Image.Source>
-                                    </Image>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                                    <!--  Product Name  -->
-                                    <Label Grid.Row="1"
-                                           Margin="10,0,0,4"
-                                           FontSize="14"
-                                           TextColor="#6b6a6a"
-                                           HorizontalOptions="Start"
-                                           LineBreakMode="TailTruncation"
-                                           MaxLines="1"
-                                           Text="{Binding Name}" />
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Settings}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                                    <StackLayout Grid.Row="2"
-                                                 Margin="10,0,0,4"
-                                                 Orientation="Horizontal"
-                                                 Spacing="2">
-                                        <!--  Product Price  -->
-                                        <Label FontFamily="Roboto-Medium"
-                                               FontSize="16"
-                                               LineHeight="{OnPlatform Android=1.25,
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Account}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </StackLayout>
+
+                <BoxView WidthRequest="1"
+                         Grid.Row="0"
+                         Grid.Column="1"
+                         IsVisible="{OnIdiom Phone=False, Tablet=True, Desktop=True}"
+                         Color="#E5E1E3" />
+                <!--  ListView for catalog  -->
+                <ScrollView Grid.Column="2"
+                            Grid.Row="0">
+                    <VerticalStackLayout>
+                        <listView:SfListView BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
+                                                 x:Name="ListViewTile"
+                                                 Padding="{OnIdiom Default='0,8,0,0', Desktop='0,0,20,0'}"
+                                                 AutoFitMode="Height"
+                                                 HeaderTemplate="{DynamicResource CatalogDefaultHeaderTemplate}"
+                                                 HorizontalOptions="Fill"
+                                                 HeightRequest="{OnPlatform Android=800, MacCatalyst=900, WinUI=600, iOS=800}"
+                                                 IsStickyHeader="False"
+                                                 ItemSpacing="{OnIdiom Phone=5, Tablet=10, Desktop=10}"
+                                                 ItemsSource="{Binding Products}"
+                                                 Style="{DynamicResource TransparentSelectionListView}">
+
+                                <listView:SfListView.ItemTemplate>
+                                    <DataTemplate x:DataType="model:Product">
+                                        <syncEffectsView:SfEffectsView RippleBackground="{DynamicResource Gray-300}"
+                                                                       TouchDownEffects="Ripple">
+                                            <Border Stroke="#e3e3e3"
+                                                    StrokeThickness="2"
+                                                    StrokeShape="RoundRectangle 10"
+                                                    WidthRequest="{OnIdiom Phone=188, Tablet=188, Desktop=178}"
+                                                    HeightRequest="245">
+                                                <Border.Shadow>
+                                                    <Shadow Brush="#000000"
+                                                            Offset="2,2"
+                                                            Radius="8"
+                                                            Opacity="0.15" />
+                                                </Border.Shadow>
+
+                                                <Grid Margin="0"
+                                                      BackgroundColor="White"
+                                                      RowDefinitions="Auto, Auto, Auto, Auto"
+                                                      RowSpacing="0">
+
+                                                    <!--  Product Image  -->
+                                                    <Image Grid.Row="0"
+                                                           Margin="0,0,0,8"
+                                                           BackgroundColor="{DynamicResource Gray-200}"
+                                                           HeightRequest="150"
+                                                           Aspect="Fill"
+                                                           HorizontalOptions="{OnPlatform Android=Fill, iOS=Fill, WinUI=Fill}"
+                                                           WidthRequest="{OnIdiom Phone=183, Tablet=224, Desktop=178}">
+                                                        <Image.Source>
+                                                            <UriImageSource CacheValidity="14"
+                                                                            CachingEnabled="true"
+                                                                            Uri="{Binding PreviewImage}" />
+                                                        </Image.Source>
+                                                    </Image>
+
+                                                    <!--  Product Name  -->
+                                                    <Label Grid.Row="1"
+                                                           Margin="10,0,0,4"
+                                                           FontSize="14"
+                                                           TextColor="#6b6a6a"
+                                                           HorizontalOptions="Start"
+                                                           LineBreakMode="TailTruncation"
+                                                           MaxLines="1"
+                                                           Text="{Binding Name}" />
+
+                                                    <StackLayout Grid.Row="2"
+                                                                 Margin="10,0,0,4"
+                                                                 Orientation="Horizontal"
+                                                                 Spacing="2">
+                                                        <!--  Product Price  -->
+                                                        <Label FontFamily="Roboto-Medium"
+                                                               FontSize="16"
+                                                               LineHeight="{OnPlatform Android=1.25,
                                 Default=-1}"
-                                               Style="{DynamicResource SimpleLabelStyle}"
-                                               Text="{Binding DiscountPrice, StringFormat='${0:0 }'}" />
-                                        <Label Margin="5,6,0,6"
-                                               TextColor="Gray"
-                                               Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
-                                               FontSize="12"
-                                               TextDecorations="Strikethrough" />
-                                        <Label Margin="10,6,0,6"
-                                               TextColor="Gray"
-                                               Text="(49% off)"
-                                               FontSize="12" />
-                                    </StackLayout>
+                                                               Style="{DynamicResource SimpleLabelStyle}"
+                                                               Text="{Binding DiscountPrice, StringFormat='${0:0 }'}" />
+                                                        <Label Margin="5,6,0,6"
+                                                               TextColor="Gray"
+                                                               Text="{Binding ActualPrice, StringFormat='${0:0.00}'}"
+                                                               FontSize="12"
+                                                               TextDecorations="Strikethrough" />
+                                                        <Label Margin="10,6,0,6"
+                                                               TextColor="Gray"
+                                                               Text="(49% off)"
+                                                               FontSize="12" />
+                                                    </StackLayout>
 
-                                    <StackLayout Grid.Row="3"
-                                                 Margin="10,0,0,0"
-                                                 Orientation="Horizontal">
-                                        <rating:SfRating BackgroundColor="Transparent"
-                                                         Grid.Row="3"
-                                                         Grid.Column="1"
-                                                         ItemSize="13"
-                                                         ItemSpacing="1"
-                                                         RatingSettings="{DynamicResource CommonRatingSettings}"
-                                                         Style="{DynamicResource RatingStyle}"
-                                                         Value="{Binding OverallRating}" />
-                                        <Label Margin="10,0,0,0"
-                                               Text="{Binding OverallRating}"
-                                               Style="{DynamicResource SimpleLabelStyle}" />
-                                        <Label Text="/5"
-                                               Style="{DynamicResource SimpleLabelStyle}" />
-                                    </StackLayout>
-                                </Grid>
-                            </Border>
-                        </syncEffectsView:SfEffectsView>
-                    </DataTemplate>
-                </listView:SfListView.ItemTemplate>
+                                                    <StackLayout Grid.Row="3"
+                                                                 Margin="10,0,0,0"
+                                                                 Orientation="Horizontal">
+                                                        <rating:SfRating BackgroundColor="Transparent"
+                                                                         Grid.Row="3"
+                                                                         Grid.Column="1"
+                                                                         ItemSize="13"
+                                                                         ItemSpacing="1"
+                                                                         RatingSettings="{DynamicResource CommonRatingSettings}"
+                                                                         Style="{DynamicResource RatingStyle}"
+                                                                         Value="{Binding OverallRating}" />
+                                                        <Label Margin="10,0,0,0"
+                                                               Text="{Binding OverallRating}"
+                                                               Style="{DynamicResource SimpleLabelStyle}" />
+                                                        <Label Text="/5"
+                                                               Style="{DynamicResource SimpleLabelStyle}" />
+                                                    </StackLayout>
+                                                </Grid>
+                                            </Border>
+                                        </syncEffectsView:SfEffectsView>
+                                    </DataTemplate>
+                                </listView:SfListView.ItemTemplate>
 
-                <!--  Layout to customize number of columns in SfListView  -->
-                <listView:SfListView.ItemsLayout>
-                    <listView:GridLayout SpanCount="{OnIdiom Phone=2, Tablet=4, Desktop=4}" />
-                </listView:SfListView.ItemsLayout>
-            </listView:SfListView>
+                                <!--  Layout to customize number of columns in SfListView  -->
+                                <listView:SfListView.ItemsLayout>
+                                    <listView:GridLayout SpanCount="{OnIdiom Phone=2, Tablet=4, Desktop=4}" />
+                                </listView:SfListView.ItemsLayout>
+                            </listView:SfListView>
+                    </VerticalStackLayout>
+                </ScrollView>
+                <StackLayout Spacing="25"
+                             Padding="5"
+                             Grid.Row="1"
+                             Grid.Column="2"
+                             Orientation="Horizontal"
+                             IsVisible="{OnIdiom Phone=True, Tablet=False, Desktop=False}">
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Home}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Text="Home"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           TextColor="#7633DA"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Category}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Categories"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Cart"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Settings}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Settings"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Account}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                                TextColor="#5F5E60"
+                                           Text="Account"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </StackLayout>
+            </Grid>
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CategoryTilePage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CategoryTilePage.xaml
@@ -8,7 +8,7 @@
              xmlns:syncEffectsView="clr-namespace:Syncfusion.Maui.Toolkit.EffectsView;assembly=Syncfusion.Maui.Toolkit"
              x:DataType="local:CategoryTileViewModel">
     <ContentView.BindingContext>
-        <local:CategoryTileViewModel x:Name="viewModel"/>
+        <local:CategoryTileViewModel x:Name="viewModel" />
     </ContentView.BindingContext>
     <ContentView.Resources>
         <Style TargetType="listView:ListViewItem">
@@ -33,141 +33,373 @@
         </Style>
     </ContentView.Resources>
     <ContentView.Content>
-        <Grid RowDefinitions="Auto,*">
+        <Grid RowDefinitions="Auto,Auto,*">
             <Grid ColumnDefinitions="Auto,*">
-               <buttons:SfButton Background="Transparent"
-                                   IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  Margin="{OnIdiom Desktop='0,10,0,12',Default=5 }"
+                                  HeightRequest="32"
+                                  WidthRequest="120"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,0,8,0"
+                                         Orientation="Horizontal"
+                                         Spacing="8"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       Rotation="180"
+                                       IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                       FontSize="20"
+                                       Text="{DynamicResource ArrowRight}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                                <Label FontFamily="Roboto-Medium"
+                                       Text="Categories"
+                                       FontSize="16"
+                                    Style="{DynamicResource DescriptionLabelStyle}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+                <HorizontalStackLayout Grid.Column="1" Margin="5"
+                                       HorizontalOptions="End">
+                    <buttons:SfButton Background="Transparent"
                                       CornerRadius="4"
-                                      Margin="10,0,0,0"
-                                      HeightRequest="32"
-                                      WidthRequest="110"
                                       TextColor="{DynamicResource Gray-700}">
                         <buttons:SfButton.Content>
                             <DataTemplate>
                                 <StackLayout Padding="8,5,8,6"
-                                             Orientation="Horizontal"
-                                             Spacing="8"
                                              VerticalOptions="Center">
                                     <Label FontFamily="FontIcons"
-                                        Rotation="180"
-                                           FontSize="18"
-                                           Style="{DynamicResource DescriptionLabelStyle}"
-                                           Text="{DynamicResource ArrowRight}"
-                                           VerticalOptions="Center"
-                                           VerticalTextAlignment="Center" />
-                                    <Label FontFamily="Roboto-Medium"
-                                           Style="{DynamicResource DescriptionLabelStyle}"
-                                           Text="Categories"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Text="{DynamicResource Search}"
                                            VerticalOptions="Center"
                                            VerticalTextAlignment="Center" />
                                 </StackLayout>
                             </DataTemplate>
                         </buttons:SfButton.Content>
                     </buttons:SfButton>
-<HorizontalStackLayout Grid.Column="1" HorizontalOptions="End">
-                <buttons:SfButton Background="Transparent"
-                                  CornerRadius="4"
-                                  TextColor="{DynamicResource Gray-700}">
-                    <buttons:SfButton.Content>
-                        <DataTemplate>
-                            <StackLayout Padding="8,5,8,6"
-                                         VerticalOptions="Center">
-                                <Label FontFamily="FontIcons"
-                                       FontSize="18"
-                                       Style="{DynamicResource DescriptionLabelStyle}"
-                                       Text="{DynamicResource Search}"
-                                       VerticalOptions="Center"
-                                       VerticalTextAlignment="Center" />
-                            </StackLayout>
-                        </DataTemplate>
-                    </buttons:SfButton.Content>
-                </buttons:SfButton>
 
-                <buttons:SfButton Background="Transparent"
-                                  CornerRadius="4"
-                                  TextColor="{DynamicResource Gray-700}">
-                    <buttons:SfButton.Content>
-                        <DataTemplate>
-                            <StackLayout Padding="8,5,8,6"
-                                         VerticalOptions="Center">
-                                <Label FontFamily="FontIcons"
-                                       FontSize="18"
-                                       Style="{DynamicResource DescriptionLabelStyle}"
-                                       Text="{DynamicResource Cart}"
-                                       VerticalOptions="Center"
-                                       VerticalTextAlignment="Center" />
-                            </StackLayout>
-                        </DataTemplate>
-                    </buttons:SfButton.Content>
-                </buttons:SfButton>
-            </HorizontalStackLayout>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                            FontAttributes="Bold"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </HorizontalStackLayout>
             </Grid>
 
-            
-            <Border Margin="20" 
-                    Grid.Row="1"
-                    Padding="{OnIdiom Phone=0, Tablet=20, Desktop=20}"
-                    StrokeThickness="0"
-                    StrokeShape="RoundRectangle 8">
+            <BoxView HeightRequest="1"
+                     Grid.Row="1"
+                     IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=True}"
+                     Color="#E5E1E3" />
 
-                <VerticalStackLayout Spacing="15">
-                    <Label Text="Catalog"
-                            IsVisible="{OnIdiom Phone=False, Tablet=False, Desktop=True}"
-                           FontSize="14"
-                           VerticalOptions="End"
-                           Margin="30,0,0,0"
-                           TextColor="#666" />
-                    <BoxView HeightRequest="1"
-                             IsVisible="{OnIdiom Phone=False, Tablet=False, Desktop=True}"
-                             Color="#EAEAEA" />
+            <Grid Grid.Row="2"
+                  RowDefinitions="*,Auto"
+                  ColumnDefinitions="Auto,Auto,*">
 
-                    <!--  ListView for Category  -->
-                    <listView:SfListView Padding="0"
-                                         AutoFitMode="Height"
-                                         BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                                         HeightRequest="{OnIdiom Phone=700, Tablet=900, Desktop=500}"
-                                         ItemSpacing="10"
-                                         ItemsSource="{Binding Categories}"
-                                         Style="{DynamicResource TransparentSelectionListView}">
-
-                        <listView:SfListView.ItemTemplate>
-                            <DataTemplate x:DataType="local:CategoryItem">
-                                <VerticalStackLayout Spacing="6"
-                                                     HeightRequest="{OnIdiom Phone=195, Tablet=230, Desktop=185}"
-                                                     HorizontalOptions="Center">
-                                    <syncEffectsView:SfEffectsView TouchDownEffects="Ripple"
-                                                                   RippleBackground="{DynamicResource Gray-300}">
-                                        <Border Stroke="Transparent"
-                                                StrokeShape="RoundRectangle 12"
-                                                HeightRequest="{OnIdiom Phone=170, Tablet=200, Desktop=160}"
-                                                WidthRequest="{OnIdiom Phone=180, Tablet=224, Desktop=170}">
-
-                                            <Image Aspect="AspectFill"
-                                                   BackgroundColor="Transparent">
-                                                <Image.Source>
-                                                    <UriImageSource Uri="{Binding Icon}"
-                                                                    CachingEnabled="true"
-                                                                    CacheValidity="14" />
-                                                </Image.Source>
-                                            </Image>
-                                        </Border>
-                                    </syncEffectsView:SfEffectsView>
-                                    
-                                    <!--  Category Name  -->
-                                    <Label Text="{Binding Name}"
-                                           FontSize="14"
-                                           Style="{DynamicResource TitleLabelStyle}" />
-                                </VerticalStackLayout>
+                <StackLayout Spacing="{OnIdiom Tablet=40, Desktop=35}"
+                             Margin="{OnIdiom Tablet='10,0,10,0', Desktop='0,0,20,0'}"
+                             IsVisible="{OnIdiom Phone=False, Tablet=True, Desktop=True}">
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Home}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
                             </DataTemplate>
-                        </listView:SfListView.ItemTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           TextColor="#7633DA"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Category}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
 
-                        <!--  Layout to customize no. of columns in SfListView  -->
-                        <listView:SfListView.ItemsLayout>
-                            <listView:GridLayout SpanCount="{OnIdiom Phone=2, Tablet=4, Desktop=5}" />
-                        </listView:SfListView.ItemsLayout>
-                    </listView:SfListView>
-                </VerticalStackLayout>
-            </Border>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Settings}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="24"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Account}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </StackLayout>
+                <BoxView WidthRequest="1"
+                         Grid.Column="1"
+                         IsVisible="{OnIdiom Phone=False, Tablet=True, Desktop=True}"
+                         Color="#E5E1E3" />
+
+                <ScrollView Grid.Column="2"
+                            Grid.Row="0">
+                    <Border Margin="0"
+                            Padding="{OnIdiom Phone=0, Tablet=20, Desktop='0,0,40,0'}"
+                            StrokeThickness="0"
+                            StrokeShape="RoundRectangle 8">
+
+                        <VerticalStackLayout Spacing="15">
+
+                            <!--  ListView for Category  -->
+                            <listView:SfListView Padding="0"
+                                                 AutoFitMode="Height"
+                                                 BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
+                                                 HeightRequest="{OnPlatform Android=800, MacCatalyst=900, WinUI=700, iOS=800}"
+                                                 ItemSpacing="10"
+                                                 ItemsSource="{Binding Categories}"
+                                                 Style="{DynamicResource TransparentSelectionListView}">
+
+                                <listView:SfListView.ItemTemplate>
+                                    <DataTemplate x:DataType="local:CategoryItem">
+                                        <VerticalStackLayout Spacing="6"
+                                                             HeightRequest="{OnIdiom Phone=195, Tablet=230, Desktop=185}"
+                                                             HorizontalOptions="Center">
+                                            <syncEffectsView:SfEffectsView TouchDownEffects="Ripple"
+                                                                           RippleBackground="{DynamicResource Gray-300}">
+                                                <Border Stroke="Transparent"
+                                                        StrokeShape="RoundRectangle 12"
+                                                        HeightRequest="{OnIdiom Phone=170, Tablet=200, Desktop=160}"
+                                                        WidthRequest="{OnIdiom Phone=180, Tablet=224, Desktop=170}">
+
+                                                    <Image Aspect="AspectFill"
+                                                           BackgroundColor="Transparent">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding Icon}"
+                                                                            CachingEnabled="true"
+                                                                            CacheValidity="14" />
+                                                        </Image.Source>
+                                                    </Image>
+                                                </Border>
+                                            </syncEffectsView:SfEffectsView>
+
+                                            <!--  Category Name  -->
+                                            <Label Text="{Binding Name}"
+                                                   FontSize="14"
+                                                   Style="{DynamicResource TitleLabelStyle}" />
+                                        </VerticalStackLayout>
+                                    </DataTemplate>
+                                </listView:SfListView.ItemTemplate>
+
+                                <!--  Layout to customize no. of columns in SfListView  -->
+                                <listView:SfListView.ItemsLayout>
+                                    <listView:GridLayout SpanCount="{OnIdiom Phone=2, Tablet=4, Desktop=5}" />
+                                </listView:SfListView.ItemsLayout>
+                            </listView:SfListView>
+                        </VerticalStackLayout>
+                    </Border>
+                </ScrollView>
+                <StackLayout Spacing="25"
+                             Padding="5"
+                             Grid.Row="1"
+                             Grid.Column="2"
+                             Orientation="Horizontal"
+                             IsVisible="{OnIdiom Phone=True, Tablet=False, Desktop=False}">
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Home}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Text="Home"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           TextColor="#7633DA"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Category}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Categories"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Cart}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Cart"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Settings}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                           Text="Settings"
+                                           TextColor="#5F5E60"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+
+                    <buttons:SfButton Background="Transparent"
+                                      CornerRadius="4"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                           FontSize="22"
+                                           FontAttributes="Bold"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource Account}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                            <Label FontFamily="Roboto-Medium"
+                                                TextColor="#5F5E60"
+                                           Text="Account"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+                </StackLayout>
+            </Grid>
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CategoryTilePage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CategoryTilePage.xaml
@@ -4,6 +4,7 @@
              x:Class="EssentialMAUIUIKit.Views.Catalog.CategoryTilePage"
              xmlns:listView="clr-namespace:Syncfusion.Maui.ListView;assembly=Syncfusion.Maui.ListView"
              xmlns:local="clr-namespace:EssentialMAUIUIKit"
+             xmlns:buttons="clr-namespace:Syncfusion.Maui.Toolkit.Buttons;assembly=Syncfusion.Maui.Toolkit"
              xmlns:syncEffectsView="clr-namespace:Syncfusion.Maui.Toolkit.EffectsView;assembly=Syncfusion.Maui.Toolkit"
              x:DataType="local:CategoryTileViewModel">
     <ContentView.BindingContext>
@@ -17,13 +18,13 @@
                         <VisualState x:Name="Normal">
                             <VisualState.Setters>
                                 <Setter Property="Background"
-                        Value="Transparent" />
+                                        Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                         <VisualState x:Name="PointerOver">
                             <VisualState.Setters>
                                 <Setter Property="Background"
-                        Value= "Transparent" />
+                                        Value="Transparent" />
                             </VisualState.Setters>
                         </VisualState>
                     </VisualStateGroup>
@@ -32,68 +33,107 @@
         </Style>
     </ContentView.Resources>
     <ContentView.Content>
+        <Grid RowDefinitions="Auto,*">
 
-        <Grid>
-            <!--  ListView for Category  -->
-            <listView:SfListView BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                                 Grid.Row="1"
-                                 Padding="8"
-                                 AutoFitMode="Height"
-                                 HorizontalOptions="Fill"
-                                 ItemSpacing="8"
-                                 ItemsSource="{Binding Categories}"
-                                 Style="{DynamicResource TransparentSelectionListView}">
+            <HorizontalStackLayout HorizontalOptions="End">
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       FontSize="18"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="{DynamicResource Search}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
 
-                <listView:SfListView.ItemTemplate>
-                    <DataTemplate x:DataType="local:CategoryItem">
-                        <syncEffectsView:SfEffectsView
-                            RippleBackground="{DynamicResource Gray-300}"
-                            TouchDownEffects="Ripple">
-                            <Grid RowDefinitions="Auto, Auto"
-                                  RowSpacing="8">
+                <buttons:SfButton Background="Transparent"
+                                  CornerRadius="4"
+                                  TextColor="{DynamicResource Gray-700}">
+                    <buttons:SfButton.Content>
+                        <DataTemplate>
+                            <StackLayout Padding="8,5,8,6"
+                                         VerticalOptions="Center">
+                                <Label FontFamily="FontIcons"
+                                       FontSize="18"
+                                       Style="{DynamicResource DescriptionLabelStyle}"
+                                       Text="{DynamicResource Cart}"
+                                       VerticalOptions="Center"
+                                       VerticalTextAlignment="Center" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </buttons:SfButton.Content>
+                </buttons:SfButton>
+            </HorizontalStackLayout>
+            <Border Margin="20"
+                    Grid.Row="1"
+                    Padding="20"
+                    StrokeThickness="0"
+                    StrokeShape="RoundRectangle 8">
 
-                                <!--  Category Image  -->
-                                <Border Stroke="Transparent"
-                                        StrokeShape="RoundRectangle 10"
-                                        HeightRequest="{OnIdiom Phone=170,
-                        Tablet=240,
-                        Desktop=170}"
-                                        WidthRequest="{OnIdiom Phone=160,
-                       Tablet=224,
-                       Desktop=164}">
-                                    <Image
-                                        Grid.Row="0"
-                                        Aspect="Fill"
-                                        BackgroundColor="Transparent">
-                                        <Image.Source>
-                                            <UriImageSource
-                                                CacheValidity="14"
-                                                CachingEnabled="true"
-                                                Uri="{Binding Icon}"/>
-                                        </Image.Source>
-                                    </Image>
-                                </Border>
+                <VerticalStackLayout Spacing="15">
+                    <Label Text="Catalog"
+                           FontSize="14"
+                           VerticalOptions="End"
+                           Margin="30,0,0,0"
+                           TextColor="#666" />
+                    <BoxView HeightRequest="1"
+                             Color="#EAEAEA" />
 
+                    <!--  ListView for Category  -->
+                    <listView:SfListView Padding="0"
+                                         AutoFitMode="Height"
+                                         BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
+                                         HeightRequest="450"
+                                         ItemSpacing="10"
+                                         ItemsSource="{Binding Categories}"
+                                         Style="{DynamicResource TransparentSelectionListView}">
 
-                                <!--  Category Name  -->
-                                <Label
-                                    Grid.Row="1"
-                                    Margin="0,0,0,8"
-                                    FontSize="14"
-                                    Style="{DynamicResource TitleLabelStyle}"
-                                    Text="{Binding Name}"/>
+                        <listView:SfListView.ItemTemplate>
+                            <DataTemplate x:DataType="local:CategoryItem">
+                                <VerticalStackLayout Spacing="6"
+                                                     HeightRequest="185"
+                                                     HorizontalOptions="Center">
+                                    <syncEffectsView:SfEffectsView TouchDownEffects="Ripple"
+                                                                   RippleBackground="{DynamicResource Gray-300}">
+                                        <Border Stroke="Transparent"
+                                                StrokeShape="RoundRectangle 10"
+                                                HeightRequest="{OnIdiom Phone=170, Tablet=240, Desktop=160}"
+                                                WidthRequest="{OnIdiom Phone=160, Tablet=224, Desktop=170}">
 
-                            </Grid>
-                        </syncEffectsView:SfEffectsView>
-                    </DataTemplate>
-                </listView:SfListView.ItemTemplate>
-                <!--  Layout to customize no. of columns in SfListView  -->
-                <listView:SfListView.ItemsLayout>
-                    <listView:GridLayout SpanCount="{OnPlatform WinUI=4, Android=2, iOS=2, MacCatalyst=4}"/>
-                </listView:SfListView.ItemsLayout>
+                                            <Image Aspect="AspectFill"
+                                                   BackgroundColor="Transparent">
+                                                <Image.Source>
+                                                    <UriImageSource Uri="{Binding Icon}"
+                                                                    CachingEnabled="true"
+                                                                    CacheValidity="14" />
+                                                </Image.Source>
+                                            </Image>
+                                        </Border>
+                                    </syncEffectsView:SfEffectsView>
+                                    
+                                    <!--  Category Name  -->
+                                    <Label Text="{Binding Name}"
+                                           FontSize="14"
+                                           Style="{DynamicResource TitleLabelStyle}" />
+                                </VerticalStackLayout>
+                            </DataTemplate>
+                        </listView:SfListView.ItemTemplate>
 
-            </listView:SfListView>
-
+                        <!--  Layout to customize no. of columns in SfListView  -->
+                        <listView:SfListView.ItemsLayout>
+                            <listView:GridLayout SpanCount="{OnPlatform WinUI=5, Android=3, iOS=3, MacCatalyst=5}" />
+                        </listView:SfListView.ItemsLayout>
+                    </listView:SfListView>
+                </VerticalStackLayout>
+            </Border>
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CategoryTilePage.xaml
+++ b/EssentialMAUIUIKit/EssentialMAUIUIKit/Views/Catalog/CategoryTilePage.xaml
@@ -34,8 +34,37 @@
     </ContentView.Resources>
     <ContentView.Content>
         <Grid RowDefinitions="Auto,*">
-
-            <HorizontalStackLayout HorizontalOptions="End">
+            <Grid ColumnDefinitions="Auto,*">
+               <buttons:SfButton Background="Transparent"
+                                   IsVisible="{OnIdiom Phone=True, Tablet=True, Desktop=False}"
+                                      CornerRadius="4"
+                                      Margin="10,0,0,0"
+                                      HeightRequest="32"
+                                      WidthRequest="110"
+                                      TextColor="{DynamicResource Gray-700}">
+                        <buttons:SfButton.Content>
+                            <DataTemplate>
+                                <StackLayout Padding="8,5,8,6"
+                                             Orientation="Horizontal"
+                                             Spacing="8"
+                                             VerticalOptions="Center">
+                                    <Label FontFamily="FontIcons"
+                                        Rotation="180"
+                                           FontSize="18"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="{DynamicResource ArrowRight}"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                    <Label FontFamily="Roboto-Medium"
+                                           Style="{DynamicResource DescriptionLabelStyle}"
+                                           Text="Categories"
+                                           VerticalOptions="Center"
+                                           VerticalTextAlignment="Center" />
+                                </StackLayout>
+                            </DataTemplate>
+                        </buttons:SfButton.Content>
+                    </buttons:SfButton>
+<HorizontalStackLayout Grid.Column="1" HorizontalOptions="End">
                 <buttons:SfButton Background="Transparent"
                                   CornerRadius="4"
                                   TextColor="{DynamicResource Gray-700}">
@@ -72,26 +101,31 @@
                     </buttons:SfButton.Content>
                 </buttons:SfButton>
             </HorizontalStackLayout>
-            <Border Margin="20"
+            </Grid>
+
+            
+            <Border Margin="20" 
                     Grid.Row="1"
-                    Padding="20"
+                    Padding="{OnIdiom Phone=0, Tablet=20, Desktop=20}"
                     StrokeThickness="0"
                     StrokeShape="RoundRectangle 8">
 
                 <VerticalStackLayout Spacing="15">
                     <Label Text="Catalog"
+                            IsVisible="{OnIdiom Phone=False, Tablet=False, Desktop=True}"
                            FontSize="14"
                            VerticalOptions="End"
                            Margin="30,0,0,0"
                            TextColor="#666" />
                     <BoxView HeightRequest="1"
+                             IsVisible="{OnIdiom Phone=False, Tablet=False, Desktop=True}"
                              Color="#EAEAEA" />
 
                     <!--  ListView for Category  -->
                     <listView:SfListView Padding="0"
                                          AutoFitMode="Height"
                                          BackgroundColor="{AppThemeBinding Light={DynamicResource BackgroundColorLight}, Dark={DynamicResource BackgroundColorDark}}"
-                                         HeightRequest="450"
+                                         HeightRequest="{OnIdiom Phone=700, Tablet=900, Desktop=500}"
                                          ItemSpacing="10"
                                          ItemsSource="{Binding Categories}"
                                          Style="{DynamicResource TransparentSelectionListView}">
@@ -99,14 +133,14 @@
                         <listView:SfListView.ItemTemplate>
                             <DataTemplate x:DataType="local:CategoryItem">
                                 <VerticalStackLayout Spacing="6"
-                                                     HeightRequest="185"
+                                                     HeightRequest="{OnIdiom Phone=195, Tablet=230, Desktop=185}"
                                                      HorizontalOptions="Center">
                                     <syncEffectsView:SfEffectsView TouchDownEffects="Ripple"
                                                                    RippleBackground="{DynamicResource Gray-300}">
                                         <Border Stroke="Transparent"
-                                                StrokeShape="RoundRectangle 10"
-                                                HeightRequest="{OnIdiom Phone=170, Tablet=240, Desktop=160}"
-                                                WidthRequest="{OnIdiom Phone=160, Tablet=224, Desktop=170}">
+                                                StrokeShape="RoundRectangle 12"
+                                                HeightRequest="{OnIdiom Phone=170, Tablet=200, Desktop=160}"
+                                                WidthRequest="{OnIdiom Phone=180, Tablet=224, Desktop=170}">
 
                                             <Image Aspect="AspectFill"
                                                    BackgroundColor="Transparent">
@@ -129,7 +163,7 @@
 
                         <!--  Layout to customize no. of columns in SfListView  -->
                         <listView:SfListView.ItemsLayout>
-                            <listView:GridLayout SpanCount="{OnPlatform WinUI=5, Android=3, iOS=3, MacCatalyst=5}" />
+                            <listView:GridLayout SpanCount="{OnIdiom Phone=2, Tablet=4, Desktop=5}" />
                         </listView:SfListView.ItemsLayout>
                     </listView:SfListView>
                 </VerticalStackLayout>


### PR DESCRIPTION
Description:
I have updated Catalog's first 3 UI designs.

Windows:
<img width="1560" height="895" alt="Screenshot 2026-06-22 071237" src="https://github.com/user-attachments/assets/97b1f094-6455-4a83-a779-a07ba4da9943" />
<img width="1553" height="900" alt="Screenshot 2026-06-22 071827" src="https://github.com/user-attachments/assets/ba473ebe-1dc8-42b4-8bc9-2bc78d18ecf2" />
<img width="1555" height="901" alt="Screenshot 2026-06-22 071908" src="https://github.com/user-attachments/assets/ff087e48-6cff-4da0-835c-de567550b64a" />

Video:
https://github.com/user-attachments/assets/ebf2739c-38d1-4e41-9faa-9b066b777e90

Mobile:
<img width="474" height="864" alt="Screenshot 2026-06-19 at 7 28 38 pm" src="https://github.com/user-attachments/assets/843b5636-95a0-49fb-ae94-d3a80577b66f" />
<img width="474" height="864" alt="Screenshot 2026-06-19 at 7 28 18 pm" src="https://github.com/user-attachments/assets/3e06988d-8c39-4932-9b83-0af407ace0e6" />
<img width="474" height="864" alt="Screenshot 2026-06-19 at 7 27 47 pm" src="https://github.com/user-attachments/assets/fbdbb109-0a6c-49c5-adfc-e8cb0faa8354" />

Tab:
<img width="812" height="1069" alt="Screenshot 2026-06-21 at 10 27 14 pm" src="https://github.com/user-attachments/assets/9bd5d96c-d424-47e2-a9e4-60a37589c83d" />
<img width="812" height="1069" alt="Screenshot 2026-06-21 at 10 26 50 pm" src="https://github.com/user-attachments/assets/0d83240b-274f-48cf-be83-4b436ee7476d" />
<img width="812" height="1069" alt="Screenshot 2026-06-21 at 10 26 01 pm" src="https://github.com/user-attachments/assets/9274131e-2b5b-4b06-b691-0f38d2b35966" />

